### PR TITLE
Add support for work-dir input parameter

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,6 +16,7 @@ Example usage:
 uses: grisumbras/run-cpt@latest
 with:
   build-script: conan/build.py
+  work-dir: project_files/sources
 ----
 
 You can set environment variables that control Conan and CPT behaviour using
@@ -35,6 +36,10 @@ Additionally, if `CONAN_USERNAME` is not specified, the first part of
 build-script::
 Path to the build script. Given `build-script: x/y/z.py`, the action will run
 `python x/y/z.py`. `build.py` by default.
+work-dir::
+Change a current working directory to the defined in this variable. The build-script
+will be run from this directory. Defaults to empty string, that is:
+do not change the working directory.
 install::
 Install conan_package_tools before running the build script if the value is not
 `no`. If the value is `latest` install the latest version, otherwise install

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: Path to the build script
     required: false
     default: build.py
+  work-dir:
+    description: Build script will be run from this directory, defaults to a current working directory
+    required: false
+    default:
   install:
     description: what version of conan_package_tools to install
     required: false

--- a/run.js
+++ b/run.js
@@ -35,6 +35,11 @@ async function run() {
     = { env: Object.assign({CONAN_USERNAME: get_username()}, process.env)
       };
   const script = core.getInput('build-script');
+  const work_dir = core.getInput('work-dir');
+  if (work_dir) {
+    console.log(`Setting working directory to ${work_dir}...`);
+    await process.chdir(work_dir);
+  }
   console.log(`Running conan_package_tools with script ${script}...`)
   await exec.exec('python', [core.getInput('build-script')], opts);
 }

--- a/run.test.js
+++ b/run.test.js
@@ -74,3 +74,27 @@ describe('running', () => {
     delete process.env.INPUT_INSTALL;
   });
 });
+
+
+describe('running with custom work-dir', () => {
+  const cwd = process.cwd();
+  beforeAll(() => {
+    process.env.INPUT_INSTALL = "no";
+    process.env.CONAN_USERNAME = "john_doe";
+    process.env["INPUT_BUILD-SCRIPT"] = "../build.py";
+    process.env["INPUT_WORK-DIR"] = "work-dir-change";
+    process.chdir("test");
+  });
+
+  test('run() runs', () => {
+    return run.run().then(() => { return true; });
+  });
+
+  afterAll(() => {
+    process.chdir(cwd);
+    delete process.env.INPUT_WORK_DIR;
+    delete process.env.INPUT_BUILD_SCRIPT;
+    delete process.env.CONAN_USERNAME;
+    delete process.env.INPUT_INSTALL;
+  });
+});

--- a/test/work-dir-change/file.txt
+++ b/test/work-dir-change/file.txt
@@ -1,0 +1,1 @@
+This file is added, because git does not add empty directories into the index.


### PR DESCRIPTION
This parameter can be used to run one build script against different projects stored in the same repository, each in itsown directory.