### PR TITLE
Revert "Fix a false package got outdated error caused by line endings"

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -44,24 +44,11 @@ install::
 Install conan_package_tools before running the build script if the value is not
 `no`. If the value is `latest` install the latest version, otherwise install
 the version equal to that value. `latest` by default.
-lf-endings::
-Automatically convert crlf into lf endings when git is used. Requires a git repository. This fixes an error
-'package got outdated when uploading an unchanged recipe' that is caused by different line endings (crlf and lf)
-when it caused by git.
-See https://docs.conan.io/en/latest/faq/using.html?highlight=crlf#packages-got-outdated-when-uploading-an-unchanged-recipe-from-a-different-machine.
 
-The following parameters allow you to customize conan and conan_package_tools behaviour.
-It is conrolled by environment variables and there is no way to undefine a variable
-from a workflow file after it was set. For example, you cannot set CONAN_DOCKER_IMAGE and then unset it.
-This does not allow you to use strategy.matrix to run several jobs based on variables
- With these parameters you can setup the behaviour without using environment variables from a workflow file.
-Values from these parameters override the values of the corresponding environment variables,
-so you can setup default environment variables and modify the behaviour of a conan for some jobs/steps exclusivly.
+The following parameters allow you to customize conan and conan_package_tools behaviour. It is conrolled by environment variables and there is no way to undefine a variable from a workflow file after it was set. For example, you cannot set CONAN_DOCKER_IMAGE and then unset it. This does not allow you to use strategy.matrix to run several jobs based on variables. With these parameters you can setup the behaviour without using environment variables from a workflow file. Values from these parameters override the values of the corresponding environment variables, so you can setup default environment variables and modify the behaviour of a conan for some jobs/steps exclusivly.
 
 compiler::
-Sets which compiler conan should use. Use this option in combination with compiler-versions.
-Defaults to an empty string. conan_package_tools will choose a compiler based on environment variables in this case.
-Other supported values are:
+Sets which compiler conan should use. Use this option in combination with compiler-versions. Defaults to an empty string. conan_package_tools will choose a compiler based on environment variables in this case. Other supported values are:
 * gcc
 * apple_clang
 * vs
@@ -72,8 +59,7 @@ to setup, this options sets its value:
 * CONAN_APPLE_CLANG_VERIONS
 * CONAN_VISUAL_VERIONS
 docker-images::
-Overrides or clears CONAN_DOCKER_IMAGE environment variable. Set to an empty string to do nothing.
-Set to 'clear' to undefine the environment variable. Defaults to empty string.
+Overrides or clears CONAN_DOCKER_IMAGE environment variable. Set to an empty string to do nothing. Set to 'clear' to undefine the environment variable. Defaults to empty string.
 
 == Maintainer
 Dmitry Arkhipov <grisumbras@gmail.com>

--- a/action.yml
+++ b/action.yml
@@ -29,10 +29,6 @@ inputs:
     description: sets CONAN_DOCKER_IMAGE env var, set to 'clear' to delete this env var. Emty string - do nothing.
     required: false
     default:
-  lf-endings:
-    description: Automatically convert crlf into lf endings when git is used. Requires a git repository.
-    required: false
-    default: false
 runs:
   using: node12
   main: main.js

--- a/run.js
+++ b/run.js
@@ -78,12 +78,7 @@ async function run() {
     console.log(`Installing ${cpt_version}...`)
     await exec.exec('pip', ["install", cpt_version]);
   }
-  const use_lf_endings = core.getInput('lf-endings');
-  if (use_lf_endings) {
-    // Fix a faulse-positive package is outdated error due to differences in line-endings,
-    // see https://docs.conan.io/en/latest/faq/using.html?highlight=crlf#packages-got-outdated-when-uploading-an-unchanged-recipe-from-a-different-machine
-    await exec.exec('git', ['config', '--global', 'core.autocrlf', 'input']);
-  }
+
   const script = core.getInput('build-script');
   const work_dir = core.getInput('work-dir');
   if (work_dir) {


### PR DESCRIPTION
This reverts commit 0ca8b56aa6c8c826e1e3e58382228f8574b32413.
This action should be done before checkout, long before run-cpt action is called.